### PR TITLE
polish mobile UX, UI, doc

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-PoCer is a mobile-first multiplayer quiz game built as a vanilla HTML/CSS/JavaScript web application. It supports up to 5 players on a single device with difficulty-based scoring and theme-based rounds.
+PoCer is a mobile-first multiplayer quiz game built as a vanilla HTML/CSS/JavaScript web application. It supports up to 10 players on a single device with difficulty-based scoring and theme-based rounds.
 
 ## Development
 
@@ -17,26 +17,31 @@ No build step, dependencies, or package manager required.
 
 ## Architecture
 
-Four core files:
+Core files:
 
 - **index.html** - UI markup with three screens: setup, game, and recap
-- **script.js** - Game logic (~420 lines): state management, DOM manipulation, localStorage persistence
+- **script.js** - Game logic: state management, DOM manipulation, localStorage persistence, lazy loading of question themes
 - **styles.css** - Dark theme mobile-first styling with CSS custom properties
-- **questions.sample.json** - Question database organized by themes and difficulty levels (1-10)
+- **questions/index.json** - Theme metadata pointing to per-theme files (primary source)
+- **questions/<theme>.json** - One file per theme, loaded on demand
+- **questions.sample.json** - Monolithic fallback used if `questions/index.json` fails to load
 
 ### Game Flow
 
-1. Players enter names (1-5 players) and choose game length (5 or 10 rounds)
-2. Each round: random theme selected → players take turns choosing difficulty → question drawn → answer revealed → points awarded (points = difficulty level)
+1. Players enter names (1-10 players) and choose game length (5 or 10 rounds)
+2. Each round: random theme selected → players take turns choosing difficulty → question drawn → answer revealed → points awarded (points = difficulty level if correct, 0 otherwise)
 3. Game state persisted to localStorage for session resumption
 
 ### State Management
 
-Central `STATE` object in script.js tracks: players, scores, current round, theme, used questions (by theme/difficulty), and used difficulties per round. Key functions:
+Central `STATE` object in script.js tracks: players, scores, current round, theme, used questions (by theme/difficulty), used difficulties per round, and the lazy-loading cache (`themeIndex`, `loadedThemes`). Key functions:
 - `startGame()`, `nextPlayer()`, `drawQuestion()`, `onAnswer()`, `renderAll()`
 - `saveLocal()` / `loadLocal()` for persistence
+- `loadThemeIndex()` / `loadTheme()` for lazy loading themes
 
 ### Question Data Format
+
+Per-theme file (`questions/<id>.json`):
 
 ```json
 {
@@ -51,9 +56,20 @@ Central `STATE` object in script.js tracks: players, scores, current round, them
 }
 ```
 
+Index file (`questions/index.json`):
+
+```json
+{
+  "themes": [
+    {"id": "theme-id", "name": "Theme Name", "file": "theme-id.json"}
+  ]
+}
+```
+
 ## Notes
 
 - French language UI
 - Mobile-first responsive design (breakpoint at 520px)
 - Haptic feedback via `navigator.vibrate()`
 - DOM helpers: `$` (querySelector) and `$$` (querySelectorAll)
+- Themes loaded lazily — only the metadata index is fetched at startup; theme files load when first picked

--- a/index.html
+++ b/index.html
@@ -14,20 +14,19 @@
       <h1>PoCer</h1>
       <p class="subtitle">Jeu de quiz — 1 téléphone, jusqu'à 10 joueurs</p>
 
+      <section id="resumeCard" class="card hidden">
+        <h2>Partie en cours</h2>
+        <p class="resume-info" id="resumeInfo">—</p>
+        <div class="row">
+          <button type="button" id="discardBtn" class="btn ghost">Nouvelle partie</button>
+          <button type="button" id="resumeBtn" class="btn primary">Reprendre</button>
+        </div>
+      </section>
+
       <form id="playersForm" class="card" onsubmit="return false;">
         <h2>Joueurs</h2>
-        <div class="players-inputs">
-          <input type="text" name="player" placeholder="Joueur 1" required />
-          <input type="text" name="player" placeholder="Joueur 2" />
-          <input type="text" name="player" placeholder="Joueur 3" />
-          <input type="text" name="player" placeholder="Joueur 4" />
-          <input type="text" name="player" placeholder="Joueur 5" />
-          <input type="text" name="player" placeholder="Joueur 6" />
-          <input type="text" name="player" placeholder="Joueur 7" />
-          <input type="text" name="player" placeholder="Joueur 8" />
-          <input type="text" name="player" placeholder="Joueur 9" />
-          <input type="text" name="player" placeholder="Joueur 10" />
-        </div>
+        <div class="players-inputs" id="playersInputs"></div>
+        <button type="button" id="addPlayerBtn" class="btn ghost btn-add">+ Ajouter un joueur</button>
         <div class="row">
           <button type="button" id="start5" class="btn secondary">Partie courte (5 manches)</button>
           <button type="button" id="start10" class="btn primary">Partie normale (10 manches)</button>
@@ -41,34 +40,33 @@
       <header class="round-header">
         <div class="round-info">
           <span class="round-chip" aria-live="polite">Manche <span id="roundNum">1</span>/<span id="roundTotal">10</span></span>
-          <span class="theme-chip">Thème : <strong id="currentTheme">—</strong> 🎯</span>
+          <span class="theme-chip">Thème : <strong id="currentTheme">—</strong></span>
         </div>
         <div class="round-progress" aria-hidden="true" id="roundDots">
           <!-- points générés en JS -->
         </div>
       </header>
 
-      <!-- Panneau joueur courant -->
-      <section class="current-player card elevate" aria-live="polite">
-        <div class="avatar" id="currentAvatar" aria-hidden="true">A</div>
-        <div class="cp-text">
-          <div class="cp-eyebrow">À toi de jouer</div>
-          <div class="cp-name" id="currentPlayerName">—</div>
-          <div class="cp-sub" id="turnOrderSub">Ordre : —</div>
+      <!-- Panneau joueur courant + ordre -->
+      <section class="player-panel card elevate" aria-live="polite">
+        <div class="player-panel-head">
+          <div class="avatar" id="currentAvatar" aria-hidden="true">A</div>
+          <div class="cp-text">
+            <div class="cp-eyebrow">À toi de jouer</div>
+            <div class="cp-name" id="currentPlayerName">—</div>
+          </div>
         </div>
+        <div class="turn-order" id="turnOrder" aria-label="Ordre des joueurs"></div>
       </section>
 
-      <!-- Ordre des tours (chips) -->
-      <section class="turn-order" id="turnOrder" aria-label="Ordre des joueurs"></section>
-
-      <!-- Scoreboard -->
-      <section class="card">
-        <h2>Scores</h2>
+      <!-- Scoreboard (repliable) -->
+      <details id="scoreboardCard" class="card scoreboard-card" open>
+        <summary><span>Scores</span></summary>
         <ul id="scoreboard" class="scoreboard"></ul>
-      </section>
+      </details>
 
       <!-- Choix de difficulté -->
-      <section class="card">
+      <section id="difficultyCard" class="card">
         <h2>Choisis ta difficulté</h2>
         <div id="difficultyGrid" class="difficulty-grid" role="group" aria-label="Choix de difficulté"></div>
         <div id="deckEmpty" class="hint hidden">Plus de questions à cette difficulté dans ce thème.</div>
@@ -77,11 +75,11 @@
       <!-- Carte Q/R -->
       <section id="qaCard" class="card hidden">
         <div class="qa-row">
-          <div class="q">❓ <span id="questionText"></span></div>
+          <div class="q"><span id="questionText"></span></div>
           <div id="revealRow" class="reveal-row">
             <button id="showAnswerBtn" class="btn secondary" aria-expanded="false">Afficher la réponse</button>
           </div>
-          <div id="answerBlock" class="a hidden">✅ <span id="answerText"></span></div>
+          <div id="answerBlock" class="a hidden"><span id="answerText"></span></div>
           <div id="judgeRow" class="judge-row hidden">
             <button id="btnWrong" class="btn ghost">Mauvaise</button>
             <button id="btnCorrect" class="btn success">Bonne (+<span id="pts"></span>)</button>
@@ -111,6 +109,15 @@
         <span class="score"></span>
       </li>
     </template>
+
+    <template id="playerInputTpl">
+      <div class="player-input-row">
+        <input type="text" name="player" />
+        <button type="button" class="btn-remove-player" aria-label="Retirer ce joueur">−</button>
+      </div>
+    </template>
+
+    <div id="toastHost" class="toast-host" aria-live="polite" aria-atomic="true"></div>
 
   </main>
   <script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -1,4 +1,4 @@
-/* PoCer — jeu de quiz mobile-first (UX + choix 5/10 manches) */
+/* PoCer — jeu de quiz mobile-first */
 const $ = (s, ctx = document) => ctx.querySelector(s);
 const $$ = (s, ctx = document) => [...ctx.querySelectorAll(s)];
 
@@ -11,8 +11,14 @@ const screens = {
 const els = {
   // setup
   playersForm: $("#playersForm"),
+  playersInputs: $("#playersInputs"),
+  addPlayerBtn: $("#addPlayerBtn"),
   start5: $("#start5"),
   start10: $("#start10"),
+  resumeCard: $("#resumeCard"),
+  resumeBtn: $("#resumeBtn"),
+  discardBtn: $("#discardBtn"),
+  resumeInfo: $("#resumeInfo"),
   // header
   roundNum: $("#roundNum"),
   roundTotal: $("#roundTotal"),
@@ -22,9 +28,9 @@ const els = {
   currentPlayerName: $("#currentPlayerName"),
   currentAvatar: $("#currentAvatar"),
   turnOrder: $("#turnOrder"),
-  turnOrderSub: $("#turnOrderSub"),
   // scoreboard
   scoreboard: $("#scoreboard"),
+  scoreboardCard: $("#scoreboardCard"),
   // difficulty + QA
   difficultyGrid: $("#difficultyGrid"),
   qaCard: $("#qaCard"),
@@ -44,10 +50,27 @@ const els = {
   // misc
   endGameBtn: $("#endGameBtn"),
   restartBtn: $("#restartBtn"),
-  shareBtn: $("#shareBtn"),
+  toastHost: $("#toastHost"),
 };
 
-let MAX_ROUNDS = 10; // défini au démarrage selon le bouton
+let MAX_ROUNDS = 10;
+
+const MAX_PLAYERS = 10;
+const MIN_PLAYERS = 1;
+
+// Distinct, accessible colors for up to 10 players
+const PLAYER_COLORS = [
+  "#f87171", // red
+  "#fb923c", // orange
+  "#fbbf24", // amber
+  "#a3e635", // lime
+  "#34d399", // emerald
+  "#22d3ee", // cyan
+  "#60a5fa", // blue
+  "#a78bfa", // violet
+  "#f472b6", // pink
+  "#facc15", // yellow
+];
 
 // --------- État ----------
 const STATE = {
@@ -63,9 +86,8 @@ const STATE = {
   currentQA: null,
   answerRevealed: false,
   usedThemes: new Set(),
-  // Lazy loading state
-  themeIndex: null,      // Metadata from index.json
-  loadedThemes: {},      // Cache: { themeId: themeData }
+  themeIndex: null,
+  loadedThemes: {},
 };
 
 // --------- Utils ----------
@@ -89,6 +111,15 @@ function saveLocal(){
 function loadLocal(){
   try{ const raw = localStorage.getItem("pocer_state"); return raw? JSON.parse(raw): null; }catch{ return null; }
 }
+function clearSavedGame(){
+  localStorage.removeItem("pocer_state");
+}
+function saveLastNames(names){
+  try{ localStorage.setItem("pocer_lastPlayers", JSON.stringify(names)); }catch{}
+}
+function loadLastNames(){
+  try{ const raw = localStorage.getItem("pocer_lastPlayers"); return raw ? JSON.parse(raw) : null; }catch{ return null; }
+}
 function resetState(){
   STATE.players = [];
   STATE.turnIndex = 0;
@@ -101,37 +132,62 @@ function resetState(){
   STATE.currentQA = null;
   STATE.answerRevealed = false;
   STATE.usedThemes = new Set();
-  // Note: themeIndex and loadedThemes are preserved across game restarts
-  // to avoid re-fetching already loaded data
 }
 
-// --------- Data (questions) - Lazy Loading ----------
+// --------- Toast ----------
+function toast(message, opts = {}){
+  const { action, actionLabel, durationMs = 3000, variant } = opts;
+  const node = document.createElement("div");
+  node.className = "toast" + (variant ? " " + variant : "");
+  const text = document.createElement("span");
+  text.className = "toast-text";
+  text.textContent = message;
+  node.appendChild(text);
 
-// Load theme index (metadata only, ~1KB)
+  let timer;
+  const dismiss = () => {
+    clearTimeout(timer);
+    if (node.parentNode) node.parentNode.removeChild(node);
+  };
+
+  if (action) {
+    const btn = document.createElement("button");
+    btn.className = "toast-action" + (variant === "danger" ? " danger" : "");
+    btn.type = "button";
+    btn.textContent = actionLabel || "Annuler";
+    btn.addEventListener("click", () => {
+      action();
+      dismiss();
+    });
+    node.appendChild(btn);
+  }
+
+  els.toastHost.appendChild(node);
+  timer = setTimeout(dismiss, durationMs);
+  return dismiss;
+}
+
+// --------- Données (questions) — Lazy Loading ----------
 async function loadThemeIndex(){
   try{
     const res = await fetch("questions/index.json", {cache:"no-store"});
     if(!res.ok) throw new Error("HTTP "+res.status);
     STATE.themeIndex = await res.json();
-    STATE.questions = { themes: [] }; // Will be populated lazily
+    STATE.questions = { themes: [] };
     STATE.loadedThemes = {};
     return true;
   }catch(e){
-    // Fallback: load monolithic file
-    console.log("Fallback to questions.sample.json");
     return await loadQuestionsFallback();
   }
 }
 
-// Fallback: load the full monolithic file
 async function loadQuestionsFallback(){
   try{
     const res = await fetch("questions.sample.json", {cache:"no-store"});
     if(!res.ok) throw new Error("HTTP "+res.status);
     STATE.questions = await res.json();
-    STATE.themeIndex = null; // Mark as using fallback mode
+    STATE.themeIndex = null;
     STATE.loadedThemes = {};
-    // Pre-populate loadedThemes cache with all themes
     STATE.questions.themes.forEach(t => STATE.loadedThemes[t.id] = t);
     return true;
   }catch(e){
@@ -148,26 +204,18 @@ async function loadQuestionsFallback(){
   }
 }
 
-// Load a specific theme on demand
 async function loadTheme(themeId){
-  // Already loaded?
   if(STATE.loadedThemes[themeId]) return STATE.loadedThemes[themeId];
-
-  // Using fallback mode (monolithic)?
   if(!STATE.themeIndex){
     return STATE.questions.themes.find(t=>t.id===themeId) || null;
   }
-
-  // Find theme metadata in index
   const meta = STATE.themeIndex.themes.find(t=>t.id===themeId);
   if(!meta) return null;
-
   try{
     const res = await fetch(`questions/${meta.file}`, {cache:"no-store"});
     if(!res.ok) throw new Error("HTTP "+res.status);
     const themeData = await res.json();
     STATE.loadedThemes[themeId] = themeData;
-    // Also add to STATE.questions.themes for compatibility
     if(!STATE.questions.themes.find(t=>t.id===themeId)){
       STATE.questions.themes.push(themeData);
     }
@@ -178,12 +226,6 @@ async function loadTheme(themeId){
   }
 }
 
-// Get theme by ID (sync, only from cache/loaded)
-function getThemeById(id){
-  return STATE.loadedThemes[id] || STATE.questions.themes.find(t=>t.id===id) || null;
-}
-
-// Get all available theme IDs (from index or fallback)
 function getAllThemeIds(){
   if(STATE.themeIndex){
     return STATE.themeIndex.themes.map(t=>t.id);
@@ -191,10 +233,6 @@ function getAllThemeIds(){
   return STATE.questions.themes.map(t=>t.id);
 }
 
-// Legacy function for compatibility
-async function loadQuestions(){
-  await loadThemeIndex();
-}
 function ensureUsedQuestionsPaths(themeId){
   if(!STATE.usedQuestions[themeId]) STATE.usedQuestions[themeId] = {};
   for(let d=1; d<=10; d++){ if(!STATE.usedQuestions[themeId][d]) STATE.usedQuestions[themeId][d] = []; }
@@ -213,7 +251,7 @@ function drawQuestion(theme, d){
   if(!cand.length) return null;
   const {qa,idx} = cand[randInt(0,cand.length-1)];
   STATE.usedQuestions[theme.id][d] = [...used, idx];
-  return {...qa, diff:d};
+  return {...qa, diff:d, _idx: idx};
 }
 function hasRemainingQuestions(theme){
   for(let d=1; d<=10; d++){
@@ -225,25 +263,18 @@ function hasRemainingQuestions(theme){
 }
 async function pickRandomTheme(){
   const allIds = getAllThemeIds();
-  // Filter out already used themes
   const candidateIds = allIds.filter(id => !STATE.usedThemes.has(id));
   if(!candidateIds.length) return null;
 
-  // Prefer themes that aren't the last one used
   const pool = candidateIds.length > 1
     ? candidateIds.filter(id => id !== STATE.lastThemeId)
     : candidateIds;
 
-  // Pick random theme ID
   const pickedId = pool[randInt(0, pool.length - 1)];
-
-  // Lazy load the theme
   const theme = await loadTheme(pickedId);
   if(!theme) return null;
 
-  // Verify it has remaining questions
   if(!hasRemainingQuestions(theme)){
-    // Mark as used and try again
     STATE.usedThemes.add(pickedId);
     return await pickRandomTheme();
   }
@@ -252,17 +283,66 @@ async function pickRandomTheme(){
   return theme;
 }
 
+// --------- Joueurs (setup dynamique) ----------
+function currentPlayerInputs(){
+  return $$("input[name=player]", els.playersInputs);
+}
+function updateRemoveButtonsVisibility(){
+  const rows = $$(".player-input-row", els.playersInputs);
+  rows.forEach((row, i) => {
+    const btn = row.querySelector(".btn-remove-player");
+    if (!btn) return;
+    btn.style.visibility = rows.length > MIN_PLAYERS ? "visible" : "hidden";
+  });
+  els.addPlayerBtn.disabled = rows.length >= MAX_PLAYERS;
+  els.addPlayerBtn.textContent = rows.length >= MAX_PLAYERS
+    ? `Maximum ${MAX_PLAYERS} joueurs`
+    : "+ Ajouter un joueur";
+  rows.forEach((row, i) => {
+    const input = row.querySelector("input");
+    input.placeholder = `Joueur ${i+1}`;
+  });
+}
+function addPlayerInput(value = ""){
+  const rows = $$(".player-input-row", els.playersInputs);
+  if (rows.length >= MAX_PLAYERS) return;
+  const tpl = $("#playerInputTpl");
+  const node = tpl.content.cloneNode(true);
+  const row = node.querySelector(".player-input-row");
+  const input = row.querySelector("input");
+  const removeBtn = row.querySelector(".btn-remove-player");
+  input.value = value;
+  removeBtn.addEventListener("click", () => {
+    row.remove();
+    updateRemoveButtonsVisibility();
+  });
+  els.playersInputs.appendChild(row);
+  updateRemoveButtonsVisibility();
+}
+function renderInitialPlayerInputs(){
+  els.playersInputs.innerHTML = "";
+  const last = loadLastNames();
+  if (last && last.length >= 2) {
+    last.slice(0, MAX_PLAYERS).forEach(n => addPlayerInput(n));
+  } else {
+    addPlayerInput();
+    addPlayerInput();
+  }
+}
+
 // --------- UI helpers ----------
 function showScreen(name){
   Object.values(screens).forEach(s=>s.classList.remove("active"));
   screens[name].classList.add("active");
+}
+function playerColor(p){
+  return PLAYER_COLORS[(p?.colorIdx ?? 0) % PLAYER_COLORS.length];
 }
 function renderRoundHeader(){
   els.roundNum.textContent = String(STATE.round);
   els.roundTotal.textContent = String(MAX_ROUNDS);
   els.currentTheme.textContent = STATE.theme ? STATE.theme.name : "—";
 
-  // points de progression : (re)générer si besoin
   if (els.roundDotsWrap.childElementCount !== MAX_ROUNDS){
     els.roundDotsWrap.innerHTML = "";
     for (let i=1; i<=MAX_ROUNDS; i++){
@@ -282,17 +362,17 @@ function renderCurrentPlayer(){
   const p = STATE.players[STATE.turnIndex];
   els.currentPlayerName.textContent = p?.name ?? "—";
   els.currentAvatar.textContent = initials(p?.name);
-  els.turnOrderSub.textContent = `Ordre : ${computeTurnOrderNames().join(" → ")}`;
+  els.currentAvatar.style.setProperty("--player-color", playerColor(p));
 
-  // turn chips
   els.turnOrder.innerHTML = "";
-  computeTurnOrderNames(true).forEach(({name,isActive},i)=>{
+  computeTurnOrder(true).forEach(({player, isActive}, i) => {
     const chip = document.createElement("div");
-    chip.className = "turn-chip"+(isActive?" active":"");
+    chip.className = "turn-chip" + (isActive ? " active" : "");
+    chip.style.setProperty("--player-color", playerColor(player));
     const b = document.createElement("span");
     b.className = "badge"; b.textContent = String(i+1);
     const n = document.createElement("span");
-    n.className = "name"; n.textContent = name;
+    n.className = "name"; n.textContent = player.name;
     chip.append(b,n);
     els.turnOrder.appendChild(chip);
   });
@@ -304,6 +384,8 @@ function renderScoreboard(intoEl){
   const tpl = $("#playerRowTpl");
   STATE.players.forEach(p=>{
     const node = tpl.content.cloneNode(true);
+    const row = node.querySelector(".score-row");
+    row.style.setProperty("--player-color", playerColor(p));
     node.querySelector(".name").textContent = p.name;
     node.querySelector(".score").textContent = String(p.score);
     intoEl.appendChild(node);
@@ -326,6 +408,7 @@ function renderDifficulties(){
 function renderQA(){
   if(STATE.currentQA){
     els.qaCard.classList.remove("hidden");
+    els.scoreboardCard.open = false;
     els.questionText.textContent = STATE.currentQA.q;
     els.answerText.textContent = STATE.currentQA.a;
     els.ptsSpan.textContent = String(STATE.currentQA.diff);
@@ -343,6 +426,7 @@ function renderQA(){
     }
   }else{
     els.qaCard.classList.add("hidden");
+    els.scoreboardCard.open = true;
   }
 }
 function renderAll(){
@@ -361,25 +445,25 @@ async function setThemeForRound(){
   STATE.answerRevealed = false;
 
   if(!STATE.theme){
-    alert("Plus de thèmes disponibles (ou plus de questions). Fin de partie !");
+    toast("Plus de thèmes disponibles. Fin de partie.", { variant: "danger", durationMs: 2500 });
     finishGame();
     return;
   }
   STATE.usedThemes.add(STATE.theme.id);
   saveLocal();
 }
-function computeTurnOrderNames(withActiveFlag=false){
-  const names = [];
+function computeTurnOrder(withActiveFlag = false){
+  const order = [];
   for(let i=0;i<STATE.players.length;i++){
     const idx = (STATE.starterIndex + i) % STATE.players.length;
-    const name = STATE.players[idx].name;
+    const player = STATE.players[idx];
     if(withActiveFlag){
-      names.push({name, isActive: idx===STATE.turnIndex});
+      order.push({ player, isActive: idx === STATE.turnIndex });
     }else{
-      names.push(name + (idx===STATE.turnIndex ? " (★)" : ""));
+      order.push(player);
     }
   }
-  return names;
+  return order;
 }
 async function nextPlayer(){
   STATE.currentQA = null;
@@ -423,23 +507,69 @@ function onShowAnswer(){
   if (navigator.vibrate) navigator.vibrate([8,20,8]);
   renderAll();
 }
+
+function snapshotForUndo(){
+  const themeId = STATE.theme?.id ?? null;
+  const usedAtTheme = themeId ? (STATE.usedQuestions[themeId] || {}) : {};
+  return {
+    players: STATE.players.map(p => ({...p})),
+    turnIndex: STATE.turnIndex,
+    starterIndex: STATE.starterIndex,
+    round: STATE.round,
+    themeId,
+    usedDifficulties: [...STATE.usedDifficulties],
+    usedQuestionsAtTheme: Object.fromEntries(Object.entries(usedAtTheme).map(([k, v]) => [k, [...v]])),
+    currentQA: STATE.currentQA ? {...STATE.currentQA} : null,
+    answerRevealed: STATE.answerRevealed,
+    lastThemeId: STATE.lastThemeId,
+    usedThemes: [...STATE.usedThemes],
+  };
+}
+async function restoreFromSnapshot(snap){
+  STATE.players = snap.players;
+  STATE.turnIndex = snap.turnIndex;
+  STATE.starterIndex = snap.starterIndex;
+  STATE.round = snap.round;
+  STATE.usedDifficulties = new Set(snap.usedDifficulties);
+  STATE.currentQA = snap.currentQA;
+  STATE.answerRevealed = snap.answerRevealed;
+  STATE.lastThemeId = snap.lastThemeId;
+  STATE.usedThemes = new Set(snap.usedThemes);
+  if (snap.themeId) {
+    STATE.theme = await loadTheme(snap.themeId);
+    STATE.usedQuestions[snap.themeId] = snap.usedQuestionsAtTheme;
+  }
+  showScreen("game");
+  saveLocal();
+  renderAll();
+}
+
 async function onAnswer(isCorrect){
   if(!STATE.currentQA) return;
+  const snap = snapshotForUndo();
+  const player = STATE.players[STATE.turnIndex];
+  const playerName = player.name;
+  const pts = STATE.currentQA.diff;
   if(isCorrect){
-    const player = STATE.players[STATE.turnIndex];
-    player.score += STATE.currentQA.diff;
+    player.score += pts;
   }
+  if (navigator.vibrate) navigator.vibrate(isCorrect ? [10, 30, 10] : 25);
   saveLocal();
   await nextPlayer();
+  toast(
+    isCorrect ? `+${pts} pt${pts>1?"s":""} pour ${playerName}` : `0 pt pour ${playerName}`,
+    { action: () => restoreFromSnapshot(snap), actionLabel: "Annuler", durationMs: 3000 }
+  );
 }
 
 // --------- Game flow ----------
 async function startGame(players, rounds){
   resetState();
-  MAX_ROUNDS = rounds;                    // <- défini par le bouton choisi
-  STATE.players = players.map(n=>({name:n, score:0}));
+  MAX_ROUNDS = rounds;
+  STATE.players = players.map((n, i) => ({ name: n, score: 0, colorIdx: i }));
   STATE.starterIndex = 0;
   STATE.turnIndex = STATE.starterIndex;
+  saveLastNames(players);
   await loadThemeIndex();
   await setThemeForRound();
   saveLocal();
@@ -447,6 +577,10 @@ async function startGame(players, rounds){
   renderAll();
 }
 function finishGame(){
+  if (!STATE.players.length) {
+    showScreen("setup");
+    return;
+  }
   const best = Math.max(...STATE.players.map(p=>p.score));
   const winners = STATE.players.filter(p=>p.score===best);
   els.winners.textContent = winners.length>1
@@ -454,66 +588,94 @@ function finishGame(){
     : `Vainqueur : ${winners[0].name} (${best} pts)`;
   renderScoreboard(els.finalTable);
   showScreen("recap");
+  clearSavedGame();
 }
-function shareScores(){
-  const lines = [
-    "PoCer — Résultats",
-    ...STATE.players.map(p=>`${p.name}: ${p.score} pts`),
-    `(Manches jouées: ${Math.min(STATE.round-1, MAX_ROUNDS)}/${MAX_ROUNDS})`
-  ];
-  const text = lines.join("\n");
-  if(navigator.share){ navigator.share({text}).catch(()=>{}); }
-  else { navigator.clipboard.writeText(text).then(()=>alert("Scores copiés !")); }
+
+function confirmEndGame(){
+  toast("Terminer la partie ?", {
+    variant: "danger",
+    actionLabel: "Confirmer",
+    action: finishGame,
+    durationMs: 4000,
+  });
 }
 
 // --------- Events ----------
 function collectNames(){
-  const names = $$("input[name=player]", els.playersForm).map(i=>i.value.trim()).filter(Boolean);
-  if(names.length<1 || names.length>10){ alert("Entre 1 à 10 joueurs."); return null; }
+  const names = currentPlayerInputs().map(i => i.value.trim()).filter(Boolean);
+  if (names.length < MIN_PLAYERS) {
+    toast(`Au moins ${MIN_PLAYERS} joueur requis.`, { variant: "danger" });
+    return null;
+  }
+  if (names.length > MAX_PLAYERS) {
+    toast(`Maximum ${MAX_PLAYERS} joueurs.`, { variant: "danger" });
+    return null;
+  }
   return names;
 }
-els.start10.addEventListener("click", ()=>{
+
+els.addPlayerBtn.addEventListener("click", () => addPlayerInput());
+els.start10.addEventListener("click", () => {
   const names = collectNames(); if(!names) return;
   startGame(names, 10);
 });
-els.start5.addEventListener("click", ()=>{
+els.start5.addEventListener("click", () => {
   const names = collectNames(); if(!names) return;
   startGame(names, 5);
 });
 $("#showAnswerBtn").addEventListener("click", onShowAnswer);
-els.btnCorrect.addEventListener("click", ()=>onAnswer(true));
-els.btnWrong.addEventListener("click", ()=>onAnswer(false));
-els.endGameBtn.addEventListener("click", finishGame);
-els.restartBtn.addEventListener("click", ()=>{
-  localStorage.removeItem("pocer_state");
+els.btnCorrect.addEventListener("click", () => onAnswer(true));
+els.btnWrong.addEventListener("click", () => onAnswer(false));
+els.endGameBtn.addEventListener("click", confirmEndGame);
+els.restartBtn.addEventListener("click", () => {
+  clearSavedGame();
   location.reload();
 });
-els.shareBtn.addEventListener("click", shareScores);
 
-window.addEventListener("load", async ()=>{
+// --------- Resume flow ----------
+function describeSave(saved){
+  const n = (saved.players || []).length;
+  const round = saved.round || 1;
+  const total = saved.maxRounds || 10;
+  return `${n} joueur${n>1?"s":""} — manche ${Math.min(round, total)}/${total}`;
+}
+async function resumeFromSave(saved){
+  MAX_ROUNDS = saved.maxRounds || 10;
+  STATE.players = (saved.players || []).map((p, i) => ({
+    name: p.name,
+    score: p.score ?? 0,
+    colorIdx: p.colorIdx ?? i,
+  }));
+  STATE.turnIndex = saved.turnIndex ?? 0;
+  STATE.starterIndex = saved.starterIndex ?? 0;
+  STATE.round = saved.round || 1;
+  STATE.usedQuestions = saved.usedQuestions || {};
+  STATE.usedDifficulties = new Set(saved.usedDifficulties || []);
+  STATE.lastThemeId = saved.lastThemeId || null;
+  STATE.usedThemes = new Set(saved.usedThemes || []);
+  if(saved.themeId){
+    STATE.theme = await loadTheme(saved.themeId);
+  }
+  if(!STATE.theme){
+    STATE.theme = await pickRandomTheme();
+  }
+  if(STATE.theme && !STATE.usedThemes.has(STATE.theme.id)) STATE.usedThemes.add(STATE.theme.id);
+  showScreen("game");
+  renderAll();
+}
+
+window.addEventListener("load", async () => {
+  renderInitialPlayerInputs();
   await loadThemeIndex();
   const saved = loadLocal();
-  if(saved && confirm("Reprendre la partie sauvegardée ?")){
-    MAX_ROUNDS = saved.maxRounds || 10;
-    STATE.players = saved.players || [];
-    STATE.turnIndex = saved.turnIndex ?? 0;
-    STATE.starterIndex = saved.starterIndex ?? 0;
-    STATE.round = saved.round || 1;
-    STATE.usedQuestions = saved.usedQuestions || {};
-    STATE.usedDifficulties = new Set(saved.usedDifficulties || []);
-    STATE.lastThemeId = saved.lastThemeId || null;
-    STATE.usedThemes = new Set(saved.usedThemes || []);
-    // Load the saved theme (async)
-    if(saved.themeId){
-      STATE.theme = await loadTheme(saved.themeId);
-    }
-    if(!STATE.theme){
-      STATE.theme = await pickRandomTheme();
-    }
-    if(STATE.theme && !STATE.usedThemes.has(STATE.theme.id)) STATE.usedThemes.add(STATE.theme.id);
-    showScreen("game");
-    renderAll();
-  }else{
-    showScreen("setup");
+  if (saved && saved.players?.length) {
+    els.resumeInfo.textContent = describeSave(saved);
+    els.resumeCard.classList.remove("hidden");
+    els.resumeBtn.addEventListener("click", () => resumeFromSave(saved));
+    els.discardBtn.addEventListener("click", () => {
+      clearSavedGame();
+      els.resumeCard.classList.add("hidden");
+    });
   }
+  showScreen("setup");
 });

--- a/styles.css
+++ b/styles.css
@@ -9,11 +9,18 @@
   --chip:#222743;
   --chip2:#2a2f52;
   --elev:0 12px 30px rgba(0,0,0,.35);
+  --safe-top:env(safe-area-inset-top, 0px);
+  --safe-bottom:env(safe-area-inset-bottom, 0px);
+  --safe-left:env(safe-area-inset-left, 0px);
+  --safe-right:env(safe-area-inset-right, 0px);
 }
 
 *{box-sizing:border-box}
 html,body{margin:0;height:100%;background:var(--bg);color:var(--text);font-family:system-ui,-apple-system,Segoe UI,Roboto,Inter,Arial}
-main{max-width:760px;margin:0 auto;padding:16px 16px 48px}
+main{
+  max-width:760px;margin:0 auto;
+  padding:calc(16px + var(--safe-top)) calc(16px + var(--safe-right)) calc(48px + var(--safe-bottom)) calc(16px + var(--safe-left));
+}
 
 h1{margin:8px 0 4px}
 .subtitle{color:var(--muted);margin:0 0 16px}
@@ -29,99 +36,38 @@ h1{margin:8px 0 4px}
 }
 .elevate{box-shadow:var(--elev)}
 
-.row{display:flex;gap:12px;justify-content:flex-end}
-.players-inputs{display:grid;grid-template-columns:1fr;gap:10px}
+.row{display:flex;gap:12px;justify-content:flex-end;flex-wrap:wrap}
+.players-inputs{display:grid;grid-template-columns:1fr;gap:10px;margin-bottom:10px}
+.player-input-row{display:flex;gap:8px;align-items:stretch}
+.player-input-row input{flex:1}
 input{
-  width:100%;padding:12px 14px;border-radius:10px;border:1px solid #2a2d45;background:#0d1122;color:var(--text)
+  width:100%;padding:12px 14px;border-radius:10px;border:1px solid #2a2d45;background:#0d1122;color:var(--text);font-size:16px
 }
 input::placeholder{color:#6c738a}
 
+.btn-remove-player{
+  width:44px;flex-shrink:0;border-radius:10px;border:1px solid #2a2d45;
+  background:#0d1122;color:#9aa3b2;font-size:18px;font-weight:700;cursor:pointer
+}
+.btn-remove-player:hover{background:#1a1f3f;color:var(--danger)}
+.btn-add{margin-bottom:12px;width:100%}
+
 .btn{
-  appearance:none;border:0;border-radius:12px;padding:12px 14px;
-  background:#2b3054;color:#fff;font-weight:600
+  appearance:none;border:0;border-radius:12px;padding:14px 16px;
+  background:#2b3054;color:#fff;font-weight:600;font-size:15px;cursor:pointer
 }
 .btn.primary{background:var(--primary)}
 .btn.secondary{background:#39407a}
 .btn.success{background:var(--success)}
 .btn.ghost{background:transparent;border:1px solid #404567}
-.btn:disabled{opacity:.5}
+.btn:disabled{opacity:.5;cursor:not-allowed}
+
+:focus-visible{outline:2px solid var(--primary);outline-offset:2px;border-radius:6px}
 
 .round-header{
   display:flex;flex-direction:column;gap:10px;margin-top:6px;margin-bottom:8px
 }
 .round-info{display:flex;gap:8px;flex-wrap:wrap;align-items:center}
-.round-chip{
-  background:var(--chip);padding:6px 10px;border-radius:999px;font-weight:700;letter-spacing:.3px
-}
-.theme-chip{
-  background:var(--chip2);padding:6px 10px;border-radius:999px;color:#dbe3ff
-}
-.round-progress{display:flex;gap:6px}
-.dot{
-  width:8px;height:8px;border-radius:50%;background:#2e335e;opacity:.5
-}
-.dot.active{background:var(--primary);opacity:1}
-.dot.done{background:#4ade80;opacity:1}
-
-.current-player{display:flex;gap:12px;align-items:center}
-.avatar{
-  width:56px;height:56px;border-radius:12px;background:#2a2f52;display:grid;place-items:center;
-  font-weight:800;font-size:24px;letter-spacing:.5px
-}
-.cp-text{display:flex;flex-direction:column}
-.cp-eyebrow{color:#97a1ba;font-size:12px;text-transform:uppercase;letter-spacing:.6px}
-.cp-name{font-size:22px;font-weight:800}
-.cp-sub{color:#a7b0c8;font-size:13px}
-
-.turn-order{display:flex;gap:8px;flex-wrap:wrap;margin:10px 0}
-.turn-chip{
-  display:flex;align-items:center;gap:8px;
-  padding:8px 10px;border-radius:999px;background:#21264a;border:1px solid #343a6b
-}
-.turn-chip .badge{
-  width:18px;height:18px;border-radius:50%;display:grid;place-items:center;
-  background:#2a2f52;font-size:11px;color:#c9d2ff
-}
-.turn-chip.active{outline:2px solid var(--primary);background:#1f2550}
-.turn-chip .name{font-weight:700}
-
-.scoreboard{list-style:none;margin:0;padding:0;display:grid;gap:8px}
-.score-row{
-  display:flex;justify-content:space-between;align-items:center;
-  background:#141832;border:1px solid #2a2f52;padding:10px 12px;border-radius:10px
-}
-.score-row .name{font-weight:700}
-.score-row .score{font-variant-numeric:tabular-nums;background:#0d1122;padding:6px 10px;border-radius:8px}
-
-.difficulty-grid{
-  display:grid;grid-template-columns:repeat(5,1fr);gap:10px
-}
-.diff-btn{
-  padding:12px 0;border-radius:12px;border:1px solid #384076;background:#1a1f3f;color:#fff;font-weight:800
-}
-.diff-btn:disabled{opacity:.35;filter:grayscale(1)}
-.diff-btn:not(:disabled):active{transform:translateY(1px)}
-
-.qa-row .q,.qa-row .a{font-size:18px;line-height:1.4}
-.qa-row .q{margin-bottom:12px}
-.reveal-row{margin:10px 0}
-.judge-row{display:flex;gap:10px;margin-top:10px}
-.hint{color:#b7c0d7;font-size:13px}
-
-.toolbar{display:flex;justify-content:center;margin:20px 0}
-
-.winners{font-weight:800;font-size:18px;margin:8px 0 12px}
-
-/* Petits écrans */
-@media (min-width:520px){
-  .players-inputs{grid-template-columns:repeat(2,1fr)}
-  .difficulty-grid{grid-template-columns:repeat(10,1fr)}
-}
-
-/* utilités */
-.hidden{display:none !important}
-
-/* thème + manche plus visibles */
 .round-chip{
   background:#1f2a5a;
   padding:8px 12px;
@@ -131,18 +77,135 @@ input::placeholder{color:#6c738a}
   font-size:14px;
 }
 .theme-chip{
-  background:#3546a3;
-  padding:8px 12px;
+  background:transparent;
+  border:1px solid #3546a3;
+  padding:6px 12px;
   border-radius:999px;
-  color:#fff;
-  font-weight:900;
-  font-size:15px;
+  color:#dbe3ff;
+  font-weight:600;
+  font-size:14px;
 }
 .theme-chip strong{
-  font-size:18px;
-  text-decoration:underline;
+  color:#fff;
+  font-weight:700;
 }
+.round-progress{display:flex;gap:6px}
+.dot{
+  width:12px;height:12px;border-radius:50%;background:#2e335e
+}
+.dot.active{background:var(--primary);box-shadow:0 0 0 3px rgba(109,139,255,.25)}
+.dot.done{background:#4ade80}
 
-/* question/answer bloc un peu plus aéré quand affiché */
+.player-panel{display:flex;flex-direction:column;gap:12px}
+.player-panel-head{display:flex;gap:12px;align-items:center}
+.avatar{
+  width:56px;height:56px;border-radius:12px;display:grid;place-items:center;
+  font-weight:800;font-size:24px;letter-spacing:.5px;color:#0f1220;
+  background:var(--player-color, #2a2f52)
+}
+.cp-text{display:flex;flex-direction:column}
+.cp-eyebrow{color:#97a1ba;font-size:12px;text-transform:uppercase;letter-spacing:.6px}
+.cp-name{font-size:22px;font-weight:800}
+
+.turn-order{display:flex;gap:8px;flex-wrap:wrap}
+.turn-chip{
+  display:flex;align-items:center;gap:8px;
+  padding:8px 10px;border-radius:999px;background:#21264a;border:1px solid #343a6b
+}
+.turn-chip .badge{
+  width:18px;height:18px;border-radius:50%;display:grid;place-items:center;
+  background:var(--player-color, #2a2f52);font-size:11px;color:#0f1220;font-weight:800
+}
+.turn-chip.active{outline:2px solid var(--primary);background:#1f2550}
+.turn-chip .name{font-weight:700}
+
+.scoreboard-card{padding:0}
+.scoreboard-card>summary{
+  list-style:none;cursor:pointer;
+  padding:14px 16px;display:flex;justify-content:space-between;align-items:center;
+  font-weight:700;font-size:16px
+}
+.scoreboard-card>summary::-webkit-details-marker{display:none}
+.scoreboard-card>summary::after{
+  content:"▾";color:var(--muted);transition:transform .15s
+}
+.scoreboard-card[open]>summary::after{transform:rotate(180deg)}
+.scoreboard-card>.scoreboard{padding:0 16px 16px}
+
+.scoreboard{list-style:none;margin:0;padding:0;display:grid;gap:8px}
+.score-row{
+  display:flex;justify-content:space-between;align-items:center;
+  background:#141832;border:1px solid #2a2f52;padding:10px 12px;border-radius:10px;
+  border-left:4px solid var(--player-color, #2a2f52)
+}
+.score-row .name{font-weight:700}
+.score-row .score{font-variant-numeric:tabular-nums;background:#0d1122;padding:6px 10px;border-radius:8px}
+
+.difficulty-grid{
+  display:grid;grid-template-columns:repeat(5,1fr);gap:10px
+}
+.diff-btn{
+  padding:14px 0;border-radius:12px;border:0;color:#0f1220;font-weight:800;font-size:16px;cursor:pointer
+}
+.diff-btn[data-d="1"]{background:#86efac}
+.diff-btn[data-d="2"]{background:#a3e394}
+.diff-btn[data-d="3"]{background:#bde078}
+.diff-btn[data-d="4"]{background:#dfd962}
+.diff-btn[data-d="5"]{background:#f4d04a}
+.diff-btn[data-d="6"]{background:#f7b146}
+.diff-btn[data-d="7"]{background:#f59247}
+.diff-btn[data-d="8"]{background:#ef6e48}
+.diff-btn[data-d="9"]{background:#e74e4a}
+.diff-btn[data-d="10"]{background:#dc2f4f;color:#fff}
+.diff-btn:disabled{opacity:.25;filter:grayscale(.6)}
+.diff-btn:not(:disabled):active{transform:translateY(1px)}
+
+.qa-row .q,.qa-row .a{font-size:18px;line-height:1.4}
 .qa-row .q{font-size:20px;margin-bottom:14px}
 .qa-row .a{font-size:18px}
+.reveal-row{margin:10px 0}
+.judge-row{display:flex;gap:10px;margin-top:10px}
+.judge-row .btn{flex:1}
+.hint{color:#b7c0d7;font-size:13px}
+
+.toolbar{display:flex;justify-content:center;margin:20px 0}
+
+.winners{font-weight:800;font-size:18px;margin:8px 0 12px}
+
+.resume-info{color:var(--muted);margin:0 0 12px}
+
+/* Toast component */
+.toast-host{
+  position:fixed;left:0;right:0;
+  bottom:calc(16px + var(--safe-bottom));
+  display:flex;flex-direction:column;align-items:center;gap:8px;
+  padding:0 16px;pointer-events:none;z-index:1000
+}
+.toast{
+  background:#1f2547;border:1px solid #343a6b;
+  color:var(--text);padding:12px 14px;border-radius:12px;
+  display:flex;gap:12px;align-items:center;
+  box-shadow:0 8px 24px rgba(0,0,0,.4);
+  pointer-events:auto;max-width:520px;width:100%;
+  animation:toast-in .2s ease-out
+}
+.toast.danger{border-color:#7f2a3a}
+.toast .toast-text{flex:1;font-size:14px}
+.toast .toast-action{
+  background:transparent;border:0;color:var(--primary);
+  font-weight:700;cursor:pointer;padding:4px 8px;font-size:14px
+}
+.toast .toast-action.danger{color:#fca5a5}
+@keyframes toast-in{
+  from{transform:translateY(20px);opacity:0}
+  to{transform:translateY(0);opacity:1}
+}
+
+/* Petits écrans */
+@media (min-width:520px){
+  .players-inputs{grid-template-columns:repeat(2,1fr)}
+  .difficulty-grid{grid-template-columns:repeat(10,1fr)}
+}
+
+/* utilités */
+.hidden{display:none !important}


### PR DESCRIPTION
- setup with dynamic player rows (+/- buttons), persisted last names
- replace native confirm/alert with resume card + custom toasts
- undo verdict via toast that snapshots state before scoring
- per-player color palette applied to avatar, chips, score row
- difficulty buttons gradient (green→red 1-10)
- merge current-player + turn-order, scoreboard collapsible during Q/A
- iOS safe-area, focus-visible outline, larger round dots, discreet theme chip
- remove dead shareBtn references and decorative emojis
- sync CLAUDE.md with 10-player support and lazy-loaded questions